### PR TITLE
Fix list_games for gym-retro-template for Sonic reinforcement learning

### DIFF
--- a/gymr-contest.ipynb
+++ b/gymr-contest.ipynb
@@ -269,7 +269,7 @@
     }
    ],
    "source": [
-    "sorted(retro.list_games())"
+    "sorted(retro.data.list_games())"
    ]
   },
   {


### PR DESCRIPTION
Fix the list_games() function that lists all games supported by [Gym Retro](https://github.com/openai/retro):
- Add `.data` -> `retro.data.list_games()`. This used to be just `retro.list_games()`

Also, it can be run without `sorted()` for an A-Z format. 

See issue https://github.com/openai/retro/issues/74 and [remote.py](https://github.com/openai/retro-contest/blob/master/support/retro_contest/remote.py) from the 2018 Retro Contest by @endrift